### PR TITLE
disabling bullet clicks during animation

### DIFF
--- a/spec/javascripts/PluginBulletNavigatorSpec.js
+++ b/spec/javascripts/PluginBulletNavigatorSpec.js
@@ -148,4 +148,64 @@ describe("SilverTrack.Plugins.BulletNavigator", function() {
     });
   });
 
+  describe("after animation", function() {
+    var bullets = null;
+
+    beforeEach(function() {
+      plugin = new SilverTrack.Plugins.BulletNavigator({
+        container: $(".bullet-pagination", track.container.parent())
+      });
+
+      track.install(plugin);
+      track.start();
+
+      bullets = getBullets(plugin, track);
+    });
+
+    it("should call '_setupBulletClick'", function() {
+      spyOn(plugin,"_setupBulletClick");
+      plugin.afterAnimation();
+      expect(plugin._setupBulletClick).toHaveBeenCalled();
+    });
+
+    it("should able bullet click", function() {
+      var bullet1 = $(bullets[0]);
+      var bullet2 = $(bullets[1]);
+
+      bullet2.click();
+      plugin.afterAnimation();
+      bullet1.click();
+
+      expect(track.currentPage).toBe(1);
+      expect(bullet1.hasClass(plugin.options.activeClass)).toBe(true);
+      expect(bullet2.hasClass(plugin.options.activeClass)).toBe(false);
+    });
+  });
+
+  describe("click behavior", function() {
+    beforeEach(function() {
+      plugin = new SilverTrack.Plugins.BulletNavigator({
+        container: $(".bullet-pagination", track.container.parent())
+      });
+
+      track.install(plugin);
+      track.start();
+
+      bullets = getBullets(plugin, track);
+    });
+
+    it("should disable bullet click during page transition", function() {
+      var bullet1 = $(bullets[0]);
+      var bullet2 = $(bullets[1]);
+
+      expect(track.currentPage).toBe(1);
+      bullet2.click();
+      expect(track.currentPage).toBe(2);
+      bullet1.click();
+
+      expect(track.currentPage).toBe(2);
+      expect(bullet2.hasClass(plugin.options.activeClass)).toBe(true);
+      expect(bullet1.hasClass(plugin.options.activeClass)).toBe(false);
+    });
+  })
 });

--- a/src/plugins/jquery.silver_track.bullet_navigator.js
+++ b/src/plugins/jquery.silver_track.bullet_navigator.js
@@ -37,6 +37,10 @@
       this._setupBulletClick();
     },
 
+    afterAnimation: function() {
+      this._setupBulletClick();
+    },
+
     beforePagination: function(track, event) {
       var bullet = this._getBulletByPage(event.page);
       this._updateBullets(bullet);
@@ -71,11 +75,13 @@
 
     _setupBulletClick: function() {
       var self = this;
-      this._getBullets().click(function(e) {
+      var bullets = this._getBullets();
+      bullets.click(function(e) {
         e.preventDefault();
         var bullet = $(this);
         self._updateBullets(bullet);
         self.track.goToPage(bullet.data("page"));
+        bullets.unbind("click");
       });
     },
 


### PR DESCRIPTION
As described on #9 (Bullet clicks are not being disabled during animation), the chosen way to solve this is to unbind click events from bullets after bullet click occurred, and then bind click again after each animation.

```javascript
_setupBulletClick: function() {
    var self = this;
    var bullets = this._getBullets();
    bullets.click(function(e) {
    e.preventDefault();
    var bullet = $(this);
    self._updateBullets(bullet);
    self.track.goToPage(bullet.data("page"));
    bullets.unbind("click");
  });
},
```

```javascript
afterAnimation: function() {
    this._setupBulletClick();
},
```