### PR TITLE
Plugin circular navigator

### DIFF
--- a/example/css/style.css
+++ b/example/css/style.css
@@ -322,11 +322,6 @@ h2 {
   margin-top: -69px;
 }
 
-.example-7 a.prev,
-.example-7 a.next {
-  margin-top: -69px;
-}
-
 .example-2 a.prev,
 .example-2 a.next {
   margin-top: -58px;

--- a/example/css/style.css
+++ b/example/css/style.css
@@ -322,6 +322,11 @@ h2 {
   margin-top: -69px;
 }
 
+.example-7 a.prev,
+.example-7 a.next {
+  margin-top: -69px;
+}
+
 .example-2 a.prev,
 .example-2 a.next {
   margin-top: -58px;
@@ -335,4 +340,9 @@ h2 {
 .example-4 a.prev,
 .example-4 a.next {
   margin-top: -68px;
+}
+
+.example-7 a.prev,
+.example-7 a.next {
+  margin-top: -69px;
 }

--- a/example/index.html
+++ b/example/index.html
@@ -22,6 +22,7 @@
   <script type="text/javascript" src="../src/plugins/jquery.silver_track.remote_content.js" charset="utf-8"></script>
   <script type="text/javascript" src="../src/plugins/jquery.silver_track.responsive_hub_connector.js" charset="utf-8"></script>
   <script type="text/javascript" src="../src/plugins/jquery.silver_track.css3_animation.js" charset="utf-8"></script>
+  <script type="text/javascript" src="../src/plugins/jquery.silver_track.circular_navigator.js" charset="utf-8"></script>
 
   <script type="text/javascript" src="js/script.js" charset="utf-8"></script>
   <script type="text/javascript" src="js/example1.js" charset="utf-8"></script>
@@ -29,6 +30,7 @@
   <script type="text/javascript" src="js/example4.js" charset="utf-8"></script>
   <script type="text/javascript" src="js/example5.js" charset="utf-8"></script>
   <script type="text/javascript" src="js/example6.js" charset="utf-8"></script>
+  <script type="text/javascript" src="js/example7.js" charset="utf-8"></script>
 
   <script>
     $(function() {
@@ -425,6 +427,58 @@
 
       <div class="actions button-group">
         <a href="#" class="button primary icon reload">Restart</a>
+      </div>
+    </div>
+
+    <div class="pagination">
+      <a href="#" class="prev disabled"></a>
+      <a href="#" class="next disabled"></a>
+    </div>
+  </div>
+
+  <div class="track example-7">
+    <div class="inner">
+      <h2>Circular</h2>
+
+      <div class="view-port">
+        <div id="example-7" class="slider-container">
+          <div class="item">
+            <img src="http://ib1.huluim.com/video/60044632?size=220x124">
+            <p>Trailer 1</p>
+          </div>
+          <div class="item">
+            <img src="http://ib2.huluim.com/video/60063785?size=220x124">
+            <p>Trailer 2</p>
+          </div>
+          <div class="item">
+            <img src="http://ib2.huluim.com/video/60062745?size=220x124">
+            <p>Trailer 3</p>
+          </div>
+          <div class="item">
+            <img src="http://ib1.huluim.com/video/40050156?size=220x124">
+            <p>Trailer 4</p>
+          </div>
+          <div class="item">
+            <img src="http://ib1.huluim.com/video/60066740?size=220x124">
+            <p>Trailer 5</p>
+          </div>
+          <div class="item">
+            <img src="http://ib4.huluim.com/video/60062747?size=220x124">
+            <p>Trailer 6</p>
+          </div>
+          <div class="item">
+            <img src="http://ib3.huluim.com/video/60062746?size=220x124">
+            <p>Trailer 7</p>
+          </div>
+          <div class="item">
+            <img src="http://ib1.huluim.com/video/60062744?size=220x124">
+            <p>Trailer 8</p>
+          </div>
+          <div class="item">
+            <img src="http://ib2.huluim.com/video/60060717?size=220x124">
+            <p>Trailer 9</p>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/example/js/example7.js
+++ b/example/js/example7.js
@@ -13,6 +13,13 @@ jQuery(function() {
     autoPlay: false
   }));
 
+  track.install(new SilverTrack.Plugins.Css3Animation({
+    delayUnit: "s",
+    autoHeightDuration: 300,
+    autoHeightEasing: "easeInOutCubic",
+    autoHeightDelay: 1
+  }));
+
   track.install(new SilverTrack.Plugins.ResponsiveHubConnector({
     layouts: ["phone", "small-tablet", "tablet", "web"],
     onReady: function(track, options, event) {

--- a/example/js/example7.js
+++ b/example/js/example7.js
@@ -10,7 +10,8 @@ jQuery(function() {
   }));
 
   track.install(new SilverTrack.Plugins.CircularNavigator({
-    autoPlay: false
+    autoPlay: true,
+    duration: 5000
   }));
 
   track.install(new SilverTrack.Plugins.Css3Animation({

--- a/example/js/example7.js
+++ b/example/js/example7.js
@@ -1,0 +1,40 @@
+jQuery(function() {
+
+  var example = $("#example-7");
+  var parent = example.parents(".track");
+  var track = example.silverTrack(SilverTrackExample.defaults);
+
+  track.install(new SilverTrack.Plugins.Navigator({
+    prev: $("a.prev", parent),
+    next: $("a.next", parent)
+  }));
+
+  track.install(new SilverTrack.Plugins.CircularNavigator({
+    autoPlay: false
+  }));
+
+  track.install(new SilverTrack.Plugins.ResponsiveHubConnector({
+    layouts: ["phone", "small-tablet", "tablet", "web"],
+    onReady: function(track, options, event) {
+      options.onChange(track, options, event);
+    },
+
+    onChange: function(track, options, event) {
+      track.options.mode = "horizontal";
+      track.options.autoheight = false;
+      track.options.perPage = 4;
+
+      if (event.layout === "small-tablet") {
+        track.options.perPage = 3;
+
+      } else if (event.layout === "phone") {
+        track.options.mode = "vertical";
+        track.options.autoHeight = true;
+      }
+
+      track.restart({keepCurrentPage: true});
+    }
+  }));
+
+  track.start();
+});

--- a/spec/javascripts/CoreSpec.js
+++ b/spec/javascripts/CoreSpec.js
@@ -190,10 +190,9 @@ describe("$.silverTrack", function() {
 
         expect($(items[6]).css("left")).toBe("240px");
         expect($(items[6]).css("top")).toBe("332px");
-        
+
         expect($(items[7]).css("left")).toBe("240px");
         expect($(items[7]).css("top")).toBe("498px");
-
       });
 
       it("should add the width of the container", function() {

--- a/spec/javascripts/CoreSpec.js
+++ b/spec/javascripts/CoreSpec.js
@@ -190,9 +190,10 @@ describe("$.silverTrack", function() {
 
         expect($(items[6]).css("left")).toBe("240px");
         expect($(items[6]).css("top")).toBe("332px");
-
+        
         expect($(items[7]).css("left")).toBe("240px");
         expect($(items[7]).css("top")).toBe("498px");
+
       });
 
       it("should add the width of the container", function() {

--- a/spec/javascripts/PluginCircularNavigatorSpec.js
+++ b/spec/javascripts/PluginCircularNavigatorSpec.js
@@ -195,4 +195,42 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
       });
     });
   });
+
+  describe("when the autoPlay option is true", function() {
+    beforeEach(function() {
+      jasmine.Clock.useMock()
+      loadFixtures("basic.html");
+      $.fx.off = true;
+      track = helpers.basic();
+      circularPlugin = new SilverTrack.Plugins.CircularNavigator({autoPlay: true, durtion: 5000});
+      navigatorPlugin = new SilverTrack.Plugins.Navigator({
+        prev: $("a.prev", track.container.parent().parent()),
+        next: $("a.next", track.container.parent().parent())
+      });
+
+      track.install(navigatorPlugin);
+      track.install(circularPlugin);
+      track.start();
+      nextCall = spyOn(track, "next");
+    });
+  
+    it("autoPlay options should be true", function() {
+      expect(circularPlugin.options.autoPlay).toEqual(true);
+    });
+
+    it("should call next 1 time", function() {
+      jasmine.Clock.tick(5100)
+      expect(nextCall.callCount).toEqual(1);
+    });
+
+    it("should call next 2 time", function() {
+      jasmine.Clock.tick(10100)
+      expect(nextCall.callCount).toEqual(2);
+    });
+
+    it("should call next 3 times", function() {
+      jasmine.Clock.tick(15100)
+      expect(nextCall.callCount).toEqual(3);
+    });
+  });
 });

--- a/spec/javascripts/PluginCircularNavigatorSpec.js
+++ b/spec/javascripts/PluginCircularNavigatorSpec.js
@@ -1,0 +1,339 @@
+describe("SilverTrack.Plugins.CircularNavigator", function() {
+  var track = null;
+  var circularPlugin = null;
+  var navigatorPlugin = null;
+  function sharedBehaviorForPage(params, behaviorFunction) {
+    describe("(shared)", function() {
+
+      beforeEach(function() {
+        loadFixtures("basic.html");
+        $.fx.off = true;
+        track = helpers.basic();
+
+        circularPlugin = new SilverTrack.Plugins.CircularNavigator({autoPlay: false});
+        navigatorPlugin = new SilverTrack.Plugins.Navigator({
+          prev: $("a.prev", track.container.parent().parent()),
+          next: $("a.next", track.container.parent().parent())
+        });
+
+        track.install(navigatorPlugin);
+        track.install(circularPlugin);
+
+        track.start();
+
+        hasPrev = params.hasPrev;
+        hasNext = params.hasNext;
+        currentPage = params.currentPage;
+        totalPages = params.totalPages;
+        goLeft = params.goingLeft;
+
+        if (behaviorFunction) behaviorFunction();
+      });
+
+      it("should starts with 'next' and 'prev' buttons activated", function() {
+        prevButton = $(".prev");
+        nextButton = $(".next");
+
+        expect(prevButton).not.toHaveClass("disabled");
+        expect(nextButton).not.toHaveClass("disabled");
+      });
+
+      it("should bring currentPage up to date", function() {
+        expect(track.currentPage).toEqual(currentPage);
+      });
+
+      it("should bring total pages up to date", function() {
+        expect(track.totalPages).toEqual(totalPages);
+      });
+
+      it("should bring up if have previous page", function() {
+        expect(track.hasPrev()).toEqual(hasPrev);
+      });
+
+      it("should bring up if have previous page", function() {
+        expect(track.hasNext()).toEqual(hasNext);
+      });
+
+      it("should set 'goingLeft' false", function() {
+        expect(circularPlugin.goingLeft).toEqual(goLeft);
+      });
+    });
+  };
+
+  describe("starting", function() {
+    var params = {
+      hasPrev: false,
+      hasNext: true,
+      currentPage: 1,
+      totalPages: 3,
+      goingLeft: false
+    }
+
+    sharedBehaviorForPage(params);
+
+    describe("when previous button is clicked (third page)", function() {
+      params = {
+        hasPrev: true,
+        hasNext: true,
+        currentPage: 3,
+        totalPages: 4,
+        goingLeft: false
+      }
+
+      sharedBehaviorForPage(params, function() {
+        $(".prev").click();
+      });
+
+      describe(", and back button is clicked again (second page)", function() {
+        params = {
+          hasPrev: true,
+          hasNext: true,
+          currentPage: 2,
+          totalPages: 4,
+          goingLeft: false
+        }
+
+        sharedBehaviorForPage(params, function() {
+          $(".prev").click();
+          track.prev();
+        });
+      });
+
+      describe(", and next is button clicked again (first page)", function() {
+        params = {
+          hasPrev: false,
+          hasNext: true,
+          currentPage: 1,
+          totalPages: 3,
+          goingLeft: false
+        }
+
+        sharedBehaviorForPage(params, function() {
+          $(".prev").click();
+          track.next();
+        });
+      });
+    });
+
+    describe("when the next button is clicked (second page)", function() {
+      params = {
+        hasPrev: true,
+        hasNext: true,
+        currentPage: 2,
+        totalPages: 4,
+        goingLeft: false
+      }
+
+      sharedBehaviorForPage(params, function() {
+        track.next()
+      });
+
+      describe(", and back button is clicked (first page)", function() {
+        params = {
+          hasPrev: false,
+          hasNext: true,
+          currentPage: 1,
+          totalPages: 3,
+          goingLeft: false
+        }
+
+        sharedBehaviorForPage(params, function() {
+          track.prev();
+        });        
+      });
+
+      describe(", and next button is clicked (third Page)", function() {
+        params = {
+          hasPrev: true,
+          hasNext: true,
+          currentPage: 3,
+          totalPages: 4,
+          goingLeft: false
+        }
+        
+        sharedBehaviorForPage(params, function() {
+          track.next();
+          track.next();
+        });
+
+        describe(", and next button is clicked (first page)", function() {
+          params = {
+            hasPrev: false,
+            hasNext: true,
+            currentPage: 1,
+            totalPages: 3,
+            goingLeft: false
+          }
+          
+          sharedBehaviorForPage(params, function() {
+            track.next();
+            track.next();
+            track.next();
+          });
+        });
+      });
+    })
+  });
+
+  describe("when the autoPlay option is true", function() {
+    
+    beforeEach(function() {
+      jasmine.Clock.useMock()
+      loadFixtures("basic.html");
+      $.fx.off = true;
+      track = helpers.basic();
+      circularPlugin = new SilverTrack.Plugins.CircularNavigator({autoPlay: true});
+      navigatorPlugin = new SilverTrack.Plugins.Navigator({
+        prev: $("a.prev", track.container.parent().parent()),
+        next: $("a.next", track.container.parent().parent())
+      });
+
+      track.install(navigatorPlugin);
+      track.install(circularPlugin);
+      track.start();
+      nextCall = spyOn(track, "next");
+    });
+  
+    it("autoPlay options should be true", function() {
+      expect(circularPlugin.options.autoPlay).toEqual(true);
+    });
+
+    it("should call next 1 time", function() {
+      jasmine.Clock.tick(3100)
+      expect(nextCall.callCount).toEqual(1);
+    });
+
+    it("should call next 2 time", function() {
+      jasmine.Clock.tick(6100)
+      expect(nextCall.callCount).toEqual(2);
+    });
+
+    it("should call next 3 times", function() {
+      jasmine.Clock.tick(9100)
+      expect(nextCall.callCount).toEqual(3);
+    });
+  });
+
+  describe("method tests", function() {
+    beforeEach(function() {
+      jasmine.Clock.useMock();
+      loadFixtures("basic.html");
+
+      $.fx.off = true;
+      track = helpers.basic();
+      circularPlugin = new SilverTrack.Plugins.CircularNavigator();
+      navigatorPlugin = new SilverTrack.Plugins.Navigator({
+        prev: $("a.prev", track.container.parent().parent()),
+        next: $("a.next", track.container.parent().parent())
+      });
+
+      track.install(navigatorPlugin);
+      track.install(circularPlugin);
+      track.start();
+    });
+
+    describe("#initialize", function() {
+      it("should setup track options", function () {
+        var options = null;
+        circularPlugin.initialize(options);
+        expect(circularPlugin.options).toEqual(options);
+      });
+    });
+
+    describe("#onInstall", function() {
+      it("should setup track", function() {
+        circularPlugin.onInstall(track);
+        expect(circularPlugin.track).toEqual(track);
+      });
+    });
+
+    describe("#afterStart", function() {
+      it("should run the first cycle to verify and add cloned pages", function() {
+        spyOn(circularPlugin, "_hasManyPages").andReturn(true)
+        spyOn(circularPlugin, "beforePagination");
+        spyOn(circularPlugin, "afterAnimation");
+
+        circularPlugin.afterStart();
+
+        expect(circularPlugin.beforePagination).toHaveBeenCalled();
+        expect(circularPlugin.afterAnimation).toHaveBeenCalled();
+      });
+    });
+
+    describe("#afterRestart", function() {
+      it("should enable buttons", function() {
+        spyOn(circularPlugin, "_enableButtons");
+        circularPlugin.afterRestart();
+        expect(circularPlugin._enableButtons).toHaveBeenCalled()
+      });
+    });
+
+    describe("#beforePagination", function() {
+      it("should create a new cloned page if the focused page is the last full page", function() {
+        spyOn(circularPlugin, "_appendItems");
+        spyOn(circularPlugin.track, "reloadItems");
+        spyOn(circularPlugin, "_lastCompletedPage").andReturn(track.currentPage);
+
+        circularPlugin.beforePagination();
+
+        expect(circularPlugin._appendItems).toHaveBeenCalled();
+        expect(track.reloadItems).toHaveBeenCalled();
+      });
+    });
+
+    describe("#afterAnimation", function() {
+      it("should enable buttons", function() {
+        spyOn(circularPlugin, "_enableButtons");
+        circularPlugin.afterAnimation();
+        expect(circularPlugin._enableButtons).toHaveBeenCalled();
+      });
+
+      describe("when the last full page is in focus", function() {
+
+        beforeEach(function() {
+          spyOn(circularPlugin, "_lastCompletedPage").andReturn(track.currentPage);
+          spyOn(circularPlugin.track, "restart");
+          spyOn(circularPlugin, "_changeFowardPage");
+          circularPlugin.afterAnimation();
+        });
+
+        it("should restart at the same page to reload items", function() {
+          expect(track.restart).toHaveBeenCalledWith({
+            keepCurrentPage: true,
+            animate: false
+          });
+        });
+
+        it("should calculate last foward page", function() {
+          expect(circularPlugin._changeFowardPage).toHaveBeenCalled();
+        });
+
+        it("should not return to the first page", function() {
+          expect(track.restart).not.toHaveBeenCalledWith();
+        });
+      });
+
+      describe("when the cloned page is in focus", function() {
+        beforeEach(function() {
+          spyOn(track, "currentPage").andReturn(track.totalPages);
+          spyOn(track, "currentPages").andReturn(track.totalPages);
+          spyOn(track, "totalPages").andReturn(track.totalPage + 1);
+          spyOn(circularPlugin.track, "restart");
+
+          circularPlugin.afterAnimation();
+
+          it("should return to the first page", function() {
+            expect(track.restart).toHaveBeenCalledWith({
+              page: 1,
+              animate: false
+            });
+          });
+
+          it("should not restart at the same page to reload items", function() {   
+            expect(track.restart).not.toHaveBeenCalledWith();
+          });
+        });      
+      });
+    });
+  });
+});

--- a/spec/javascripts/PluginCircularNavigatorSpec.js
+++ b/spec/javascripts/PluginCircularNavigatorSpec.js
@@ -10,7 +10,7 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
         $.fx.off = true;
         track = helpers.basic();
 
-        circularPlugin = new SilverTrack.Plugins.CircularNavigator({autoPlay: false});
+        circularPlugin = new SilverTrack.Plugins.CircularNavigator();
         navigatorPlugin = new SilverTrack.Plugins.Navigator({
           prev: $("a.prev", track.container.parent().parent()),
           next: $("a.next", track.container.parent().parent())
@@ -25,7 +25,6 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
         hasNext = params.hasNext;
         currentPage = params.currentPage;
         totalPages = params.totalPages;
-        goLeft = params.goingLeft;
 
         if (behaviorFunction) behaviorFunction();
       });
@@ -53,10 +52,6 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
       it("should bring up if have previous page", function() {
         expect(track.hasNext()).toEqual(hasNext);
       });
-
-      it("should set 'goingLeft' false", function() {
-        expect(circularPlugin.goingLeft).toEqual(goLeft);
-      });
     });
   };
 
@@ -66,18 +61,16 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
       hasNext: true,
       currentPage: 1,
       totalPages: 3,
-      goingLeft: false
     }
 
     sharedBehaviorForPage(params);
 
     describe("when previous button is clicked (third page)", function() {
-      params = {
+      var params = {
         hasPrev: true,
         hasNext: true,
         currentPage: 3,
         totalPages: 4,
-        goingLeft: false
       }
 
       sharedBehaviorForPage(params, function() {
@@ -85,12 +78,11 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
       });
 
       describe(", and back button is clicked again (second page)", function() {
-        params = {
+        var params = {
           hasPrev: true,
           hasNext: true,
           currentPage: 2,
           totalPages: 4,
-          goingLeft: false
         }
 
         sharedBehaviorForPage(params, function() {
@@ -100,12 +92,11 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
       });
 
       describe(", and next is button clicked again (first page)", function() {
-        params = {
+        var params = {
           hasPrev: false,
           hasNext: true,
           currentPage: 1,
           totalPages: 3,
-          goingLeft: false
         }
 
         sharedBehaviorForPage(params, function() {
@@ -116,12 +107,11 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
     });
 
     describe("when the next button is clicked (second page)", function() {
-      params = {
+      var params = {
         hasPrev: true,
         hasNext: true,
         currentPage: 2,
         totalPages: 4,
-        goingLeft: false
       }
 
       sharedBehaviorForPage(params, function() {
@@ -129,12 +119,11 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
       });
 
       describe(", and back button is clicked (first page)", function() {
-        params = {
+        var params = {
           hasPrev: false,
           hasNext: true,
           currentPage: 1,
           totalPages: 3,
-          goingLeft: false
         }
 
         sharedBehaviorForPage(params, function() {
@@ -143,12 +132,11 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
       });
 
       describe(", and next button is clicked (third Page)", function() {
-        params = {
+        var params = {
           hasPrev: true,
           hasNext: true,
           currentPage: 3,
           totalPages: 4,
-          goingLeft: false
         }
         
         sharedBehaviorForPage(params, function() {
@@ -157,12 +145,11 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
         });
 
         describe(", and next button is clicked (first page)", function() {
-          params = {
+          var params = {
             hasPrev: false,
             hasNext: true,
             currentPage: 1,
             totalPages: 3,
-            goingLeft: false
           }
           
           sharedBehaviorForPage(params, function() {
@@ -175,52 +162,12 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
     })
   });
 
-  describe("when the autoPlay option is true", function() {
-    
-    beforeEach(function() {
-      jasmine.Clock.useMock()
-      loadFixtures("basic.html");
-      $.fx.off = true;
-      track = helpers.basic();
-      circularPlugin = new SilverTrack.Plugins.CircularNavigator({autoPlay: true});
-      navigatorPlugin = new SilverTrack.Plugins.Navigator({
-        prev: $("a.prev", track.container.parent().parent()),
-        next: $("a.next", track.container.parent().parent())
-      });
-
-      track.install(navigatorPlugin);
-      track.install(circularPlugin);
-      track.start();
-      nextCall = spyOn(track, "next");
-    });
-  
-    it("autoPlay options should be true", function() {
-      expect(circularPlugin.options.autoPlay).toEqual(true);
-    });
-
-    it("should call next 1 time", function() {
-      jasmine.Clock.tick(3100)
-      expect(nextCall.callCount).toEqual(1);
-    });
-
-    it("should call next 2 time", function() {
-      jasmine.Clock.tick(6100)
-      expect(nextCall.callCount).toEqual(2);
-    });
-
-    it("should call next 3 times", function() {
-      jasmine.Clock.tick(9100)
-      expect(nextCall.callCount).toEqual(3);
-    });
-  });
-
   describe("method tests", function() {
     beforeEach(function() {
-      jasmine.Clock.useMock();
       loadFixtures("basic.html");
-
       $.fx.off = true;
       track = helpers.basic();
+
       circularPlugin = new SilverTrack.Plugins.CircularNavigator();
       navigatorPlugin = new SilverTrack.Plugins.Navigator({
         prev: $("a.prev", track.container.parent().parent()),
@@ -229,6 +176,7 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
 
       track.install(navigatorPlugin);
       track.install(circularPlugin);
+
       track.start();
     });
 
@@ -244,95 +192,6 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
       it("should setup track", function() {
         circularPlugin.onInstall(track);
         expect(circularPlugin.track).toEqual(track);
-      });
-    });
-
-    describe("#afterStart", function() {
-      it("should run the first cycle to verify and add cloned pages", function() {
-        spyOn(circularPlugin, "_hasManyPages").andReturn(true)
-        spyOn(circularPlugin, "beforePagination");
-        spyOn(circularPlugin, "afterAnimation");
-
-        circularPlugin.afterStart();
-
-        expect(circularPlugin.beforePagination).toHaveBeenCalled();
-        expect(circularPlugin.afterAnimation).toHaveBeenCalled();
-      });
-    });
-
-    describe("#afterRestart", function() {
-      it("should enable buttons", function() {
-        spyOn(circularPlugin, "_enableButtons");
-        circularPlugin.afterRestart();
-        expect(circularPlugin._enableButtons).toHaveBeenCalled()
-      });
-    });
-
-    describe("#beforePagination", function() {
-      it("should create a new cloned page if the focused page is the last full page", function() {
-        spyOn(circularPlugin, "_appendItems");
-        spyOn(circularPlugin.track, "reloadItems");
-        spyOn(circularPlugin, "_lastCompletedPage").andReturn(track.currentPage);
-
-        circularPlugin.beforePagination();
-
-        expect(circularPlugin._appendItems).toHaveBeenCalled();
-        expect(track.reloadItems).toHaveBeenCalled();
-      });
-    });
-
-    describe("#afterAnimation", function() {
-      it("should enable buttons", function() {
-        spyOn(circularPlugin, "_enableButtons");
-        circularPlugin.afterAnimation();
-        expect(circularPlugin._enableButtons).toHaveBeenCalled();
-      });
-
-      describe("when the last full page is in focus", function() {
-
-        beforeEach(function() {
-          spyOn(circularPlugin, "_lastCompletedPage").andReturn(track.currentPage);
-          spyOn(circularPlugin.track, "restart");
-          spyOn(circularPlugin, "_changeFowardPage");
-          circularPlugin.afterAnimation();
-        });
-
-        it("should restart at the same page to reload items", function() {
-          expect(track.restart).toHaveBeenCalledWith({
-            keepCurrentPage: true,
-            animate: false
-          });
-        });
-
-        it("should calculate last foward page", function() {
-          expect(circularPlugin._changeFowardPage).toHaveBeenCalled();
-        });
-
-        it("should not return to the first page", function() {
-          expect(track.restart).not.toHaveBeenCalledWith();
-        });
-      });
-
-      describe("when the cloned page is in focus", function() {
-        beforeEach(function() {
-          spyOn(track, "currentPage").andReturn(track.totalPages);
-          spyOn(track, "currentPages").andReturn(track.totalPages);
-          spyOn(track, "totalPages").andReturn(track.totalPage + 1);
-          spyOn(circularPlugin.track, "restart");
-
-          circularPlugin.afterAnimation();
-
-          it("should return to the first page", function() {
-            expect(track.restart).toHaveBeenCalledWith({
-              page: 1,
-              animate: false
-            });
-          });
-
-          it("should not restart at the same page to reload items", function() {   
-            expect(track.restart).not.toHaveBeenCalledWith();
-          });
-        });      
       });
     });
   });

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -19,6 +19,7 @@ src_files:
   - src/plugins/jquery.silver_track.remote_content.js
   - src/plugins/jquery.silver_track.responsive_hub_connector.js
   - src/plugins/jquery.silver_track.css3_animation.js
+  - src/plugins/jquery.silver_track.circular_navigator.js
 
 # stylesheets
 #

--- a/src/plugins/jquery.silver_track.bullet_navigator.js
+++ b/src/plugins/jquery.silver_track.bullet_navigator.js
@@ -44,7 +44,7 @@
 
     afterRestart: function() {
       this._clearBullets();
-      this._createBullets()
+      this._createBullets();
 
       var bullet = this._getBulletByPage(this.track.currentPage);
       this._updateBullets(bullet);

--- a/src/plugins/jquery.silver_track.circular_navigator.js
+++ b/src/plugins/jquery.silver_track.circular_navigator.js
@@ -1,0 +1,238 @@
+/*!
+ * jQuery SilverTrack
+ * https://github.com/tulios/jquery.silver_track
+ * version: 0.4.0
+ *
+ * Circular Navigator
+ * version: 0.1.0
+ *
+ */
+
+(function($, window, document) {
+
+  $.silverTrackPlugin("CircularNavigator", {
+    defaults: {
+      autoPlay: false,
+      duration: 3000,
+      clonedClass: "cloned"
+    },
+
+    initialize: function(options) {
+      this.options = options;
+    },
+
+    onInstall: function(track) { 
+      this.track = track;
+    },
+
+    afterStart: function(track) {
+      var perPage = this.track.options.perPage;
+
+      this.itemsCount = this.track._getItems().length;
+      this.numLastItems = this.itemsCount % perPage;
+      this.totalDefaultPages = this.track.totalPages;
+      this.goingLeft = false;
+
+      this.fowardPage = this.track.currentPage;
+      this._changeFowardPage();
+      this.navigatorPlugin = this.track.findPluginByName("Navigator");
+
+      this._listenClick();
+
+      this.breakPlayElements = [
+        this.track.container,
+        this.navigatorPlugin.prev,
+        this.navigatorPlugin.next
+      ]
+
+      this.prevButton = this.breakPlayElements[1];
+      this.nextButton = this.breakPlayElements[2];
+
+      if(this.options.autoPlay === true) {
+        this._turnOnAutoPlay(this.breakPlayElements)
+      }
+
+      if (this.numLastItems === 0) {
+        this.numLastItems = this.track.options.perPage;
+      }
+
+      if (this._hasManyPages()) {
+        this.beforePagination();
+        this.afterAnimation();
+      }
+    },
+
+    afterRestart: function() {
+      if (this._hasManyPages()) {
+        this._enableButtons();
+      }
+
+      if (this.track.currentPage === this.totalDefaultPages + 1 &&
+          this.goingLeft === true) {
+        this.track.goToPage(this.track.totalPages - 1);
+        this.goingLeft = false;
+      }
+    },
+
+    beforePagination: function() {
+      if (this.track.currentPage === this._lastCompletedPage() &&
+          this.track.totalPages === this.totalDefaultPages) {
+
+        this._appendItems();
+        this.track.reloadItems();
+      }
+    },
+
+    afterAnimation: function() {
+      this._enableButtons();
+      this._changeFowardPage();
+
+      if (this.track.currentPage === this._lastCompletedPage() &&
+          this.track.totalPages === this.totalDefaultPages) {
+
+        this.track.restart({ keepCurrentPage: true, animate: false });
+      }
+
+      if (this.track.currentPage === this.track.totalPages && 
+          this.track.totalPages > this.totalDefaultPages && 
+          this.goingLeft === false ) {
+
+        this.track.reloadItems();
+        this.track.restart({page: 1, animate: false});
+        this._deleteClonedItems();
+      }
+    },
+
+    _listenClick: function() {
+      var self = this
+      this.navigatorPlugin.options.prev.click(function() {
+        if (self.track.currentPage === 1 &&
+            self.fowardPage === self.totalDefaultPages) {
+          self._appendItems();
+          self.goingLeft = true;
+          self.track.restart({ page: self.totalDefaultPages + 1, animate: false });
+        }
+      })
+    },
+
+    _deleteClonedItems: function() {
+      var items = this.track._getItems().length
+
+      for (var el = 0; el <= items - 1; el ++) {
+        var item = this.track._getItems().eq(el)
+        if (item.hasClass(this.options.clonedClass)) {
+          item.remove();
+        }
+      }
+      this.track.reloadItems();
+      this.track.restart({ keepCurrentPage: true, animate: false });
+    },
+
+    _ifCloned: function() {
+      if (this.track._getItems().last().hasClass(this.options.clonedClass)) {
+        return true;
+      }
+      return false;
+    },
+
+    _appendItems: function() {
+      if (this._ifCloned() === true) return;
+      var items = this.track._getItems().
+        slice(0, 4).
+        clone().
+        addClass(this.options.clonedClass);
+
+      this.track.container.append(items);
+      this.track.reloadItems();
+    },
+
+    _lastCompletedPage: function() {
+      return Math.trunc(this.itemsCount / this.track.options.perPage);
+    },
+
+    _enableButtons: function() {
+      if (this.track.currentPage === 1) {
+        this._enablePrevButton();
+      }
+
+      if (this.track.currentPage === this.track.totalPages) {
+        this._enableNextButton();
+      }
+    },
+
+    _enablePrevButton: function() {
+      this.prevButton.removeClass(this.navigatorPlugin.options.disabledClass);
+    },
+
+    _enableNextButton: function() {
+      this.nextButton.removeClass(this.navigatorPlugin.options.disabledClass);
+    },
+
+    _hasManyPages: function() {
+      if (this.track.totalPages !== 1) {
+        return true;
+      }
+      return false;
+    },
+
+    _changeFowardPage: function(){
+      this.fowardPage = this.track.currentPage;
+      if (this.track.currentPage === 1) {
+        this.fowardPage = this.totalDefaultPages;
+
+      } else if (this.track.currentPage === this.totalDefaultPages &&
+                 this.track.totalPages > this.totalDefaultPages) {
+        this.fowardPage = 1;
+      }
+    },
+
+    _turnOnAutoPlay: function(elements) {
+      this._mouseOverTrack(elements);
+      this._mouseOutTrack(elements);
+      this._turnOnListener();
+    },
+
+    _turnOnListener: function() {
+      var self = this;
+
+      if(this.options.autoPlay === true) {
+        timeout = setTimeout(function() {
+          self.track.next();
+          self._turnOnListener();
+        }, this.options.duration);
+      }
+    },
+
+    _breakListener: function() {
+      clearTimeout(timeout);
+      this.options.autoPlay = false;
+    },
+
+    _wakeUpListener: function() {
+      clearTimeout(timeout);
+      this.options.autoPlay = true;
+      this._turnOnListener();
+    },
+
+    _mouseOverTrack: function(elements) {
+      var self = this;
+
+      elements.forEach(function(el) {
+        el.mouseenter(function() {
+          self._breakListener();
+        });
+      });
+    },
+
+    _mouseOutTrack: function(elements) {
+      var self = this;
+
+      elements.forEach(function(el) {
+        el.mouseleave(function() {
+          self._wakeUpListener();
+        });
+      });
+    }
+  })
+
+})(jQuery, window, document);

--- a/src/plugins/jquery.silver_track.circular_navigator.js
+++ b/src/plugins/jquery.silver_track.circular_navigator.js
@@ -22,7 +22,7 @@
   $.silverTrackPlugin("CircularNavigator", {
     defaults: {
       autoPlay: true,
-      duration: 3000,
+      duration: 5000,
       clonedClass: "cloned"
     },
 
@@ -49,6 +49,7 @@
       this.totalDefaultPages = this.track.totalPages;
       this._setupTrack();
       this._bindClick();
+      if (this.options.autoPlay === true) this._turnOnAutoPlay(this.trackElements);
     },
 
     afterRestart: function() {
@@ -57,6 +58,13 @@
 
     beforePagination: function() {
       this._enableButtons()
+    },
+
+    _enableButtons: function() {
+      if (this._hasManyPages()) {
+        this.prevButton.removeClass(this.navigatorPlugin.options.disabledClass);
+        this.nextButton.removeClass(this.navigatorPlugin.options.disabledClass);
+      }
     },
 
     afterAnimation: function() {
@@ -84,13 +92,6 @@
 
       if (this.track.currentPage === this.clonedPage && this.fowardPage === 1) {
         this.track.restart({page: 1, animate: false});
-      }
-    },
-
-    _enableButtons: function() {
-      if (this._hasManyPages()) {
-        this.prevButton.removeClass(this.navigatorPlugin.options.disabledClass);
-        this.nextButton.removeClass(this.navigatorPlugin.options.disabledClass);
       }
     },
 
@@ -191,6 +192,53 @@
         return items - this.track.options.perPage;
       }
       return items;
+    },
+
+    _turnOnAutoPlay: function(elements) {
+      this._mouseOverTrack(elements);
+      this._mouseOutTrack(elements);
+      this._turnOnListener();
+    },
+
+    _turnOnListener: function() {
+      var self = this;
+
+      if(this.options.autoPlay === true) {
+        this.timeout = setInterval(function() {
+          self.track.next();
+        }, self.options.duration);
+      }
+    },
+
+    _mouseOverTrack: function(elements) {
+      var self = this;
+
+      elements.forEach(function(el) {
+        el.mouseenter(function() {
+          self._breakListener();
+        });
+      });
+    },
+
+    _mouseOutTrack: function(elements) {
+      var self = this;
+
+      elements.forEach(function(el) {
+        el.mouseleave(function() {
+          self._wakeUpListener();
+        });
+      });
+    },
+
+    _breakListener: function() {
+      clearTimeout(this.timeout);
+      this.options.autoPlay = false;
+    },
+
+    _wakeUpListener: function() {
+      clearTimeout(this.timeout);
+      this.options.autoPlay = true;
+      this._turnOnListener();
     }
   })
 

--- a/src/plugins/jquery.silver_track.circular_navigator.js
+++ b/src/plugins/jquery.silver_track.circular_navigator.js
@@ -21,7 +21,7 @@
 
   $.silverTrackPlugin("CircularNavigator", {
     defaults: {
-      autoPlay: true,
+      autoPlay: false,
       duration: 5000,
       clonedClass: "cloned"
     },


### PR DESCRIPTION
Rewriting a closed pull request for plugin to circular navigation #4. Now is compatible with Css3Animation.

The track works by cloning the first page to create a new page (cloned) at the track's end. The clone is executed when the current page is the last completed page, this way we can ensure that different item numbers will stay at the same previous page after the clone.

TODO:
[BulletNavigator] The bullet click can jump a necessary step (last completed page) to clone the first page.