### PR TITLE
Better animation controller to CircularNavigator plugin

### DIFF
--- a/spec/javascripts/PluginCircularNavigatorSpec.js
+++ b/spec/javascripts/PluginCircularNavigatorSpec.js
@@ -198,11 +198,10 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
 
   describe("when the autoPlay option is true", function() {
     beforeEach(function() {
-      jasmine.Clock.useMock()
       loadFixtures("basic.html");
       $.fx.off = true;
       track = helpers.basic();
-      circularPlugin = new SilverTrack.Plugins.CircularNavigator({autoPlay: true, durtion: 5000});
+      circularPlugin = new SilverTrack.Plugins.CircularNavigator({autoPlay: true, duration: 200});
       navigatorPlugin = new SilverTrack.Plugins.Navigator({
         prev: $("a.prev", track.container.parent().parent()),
         next: $("a.next", track.container.parent().parent())
@@ -211,7 +210,6 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
       track.install(navigatorPlugin);
       track.install(circularPlugin);
       track.start();
-      nextCall = spyOn(track, "next");
     });
   
     it("autoPlay options should be true", function() {
@@ -219,18 +217,27 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
     });
 
     it("should call next 1 time", function() {
-      jasmine.Clock.tick(5100)
-      expect(nextCall.callCount).toEqual(1);
+      waitsFor(function() { if (track.currentPage === 2) return true }, "change the current page", 300);
+
+      runs(function() {
+        expect(track.currentPage).toEqual(2);
+      })
     });
 
-    it("should call next 2 time", function() {
-      jasmine.Clock.tick(10100)
-      expect(nextCall.callCount).toEqual(2);
+    it("should call next 2 times", function() {
+      waitsFor(function() { if (track.currentPage === 3) return true }, "change the current page", 500);
+
+      runs(function() {
+        expect(track.currentPage).toEqual(3);
+      })
     });
 
     it("should call next 3 times", function() {
-      jasmine.Clock.tick(15100)
-      expect(nextCall.callCount).toEqual(3);
+      waitsFor(function() { if (track.currentPage === 1) return true }, "change the current page", 700);
+
+      runs(function() {
+        expect(track.currentPage).toEqual(1);
+      })
     });
   });
 });

--- a/src/plugins/jquery.silver_track.circular_navigator.js
+++ b/src/plugins/jquery.silver_track.circular_navigator.js
@@ -197,15 +197,16 @@
     _turnOnAutoPlay: function(elements) {
       this._mouseOverTrack(elements);
       this._mouseOutTrack(elements);
-      this._turnOnListener();
+      requestAnimationFrame(this._turnOnListener.bind(this));
     },
 
     _turnOnListener: function() {
       var self = this;
 
-      if(this.options.autoPlay === true) {
-        this.timeout = setInterval(function() {
+      if(self.options.autoPlay === true) {
+        this.timeout = setTimeout(function() {
           self.track.next();
+          requestAnimationFrame(self._turnOnListener.bind(self));
         }, self.options.duration);
       }
     },
@@ -238,7 +239,7 @@
     _wakeUpListener: function() {
       clearTimeout(this.timeout);
       this.options.autoPlay = true;
-      this._turnOnListener();
+      requestAnimationFrame(this._turnOnListener.bind(this));
     }
   })
 


### PR DESCRIPTION
This is an animation controller update to CircularNavigator plugin. The previous way used timeout to control time animation, so when a webPage that contains a automatic track is running in background, the timeout function accumulates.

The new approach uses 'requestAnimationFrame' with previous timeout function. In this way the 'requestAnimationFrame' doesn't allows that timeout function accumulates when page is in background