### PR TITLE
Bugfix circular navigator #19

### DIFF
--- a/spec/javascripts/PluginCircularNavigatorSpec.js
+++ b/spec/javascripts/PluginCircularNavigatorSpec.js
@@ -189,7 +189,7 @@ describe("SilverTrack.Plugins.CircularNavigator", function() {
 
     describe("#initialize", function() {
       it("should setup track options", function () {
-        var options = null;
+        var options = {};
         circularPlugin.initialize(options);
         expect(circularPlugin.options).toEqual(options);
       });


### PR DESCRIPTION
correcting #19.

It occurred by a wrong parameter passed in a spec

```javascript
var options = null;
```