### PR TITLE
bugfix #26 correcting circular_navigator plugin

### DIFF
--- a/javascripts/plugin/plugins/jquery.silver_track.circular_navigator.js
+++ b/javascripts/plugin/plugins/jquery.silver_track.circular_navigator.js
@@ -208,7 +208,7 @@
     },
 
     _lastCompletedPage: function() {
-      return Math.trunc(this._originalItemsCount() / this.track.options.perPage);
+      return Math.floor(this._originalItemsCount() / this.track.options.perPage);
     },
 
     _originalItemsCount: function() {


### PR DESCRIPTION
Changing Math.trunc to Math.floor to give support to IE
